### PR TITLE
Added missing license headers in buildingmonitor JS files

### DIFF
--- a/floor-analytics-demo/building-visualizer/component/ui/src/main/resources/jaggeryapps/buildingmonitor/app/pages/cdmf.page.sign-in/public/js/cloud.js
+++ b/floor-analytics-demo/building-visualizer/component/ui/src/main/resources/jaggeryapps/buildingmonitor/app/pages/cdmf.page.sign-in/public/js/cloud.js
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 function CloudManager(container, options) {
     if (!('Tau' in Math)) {
         Math.Tau = Math.PI * 2;

--- a/floor-analytics-demo/building-visualizer/component/ui/src/main/resources/jaggeryapps/buildingmonitor/app/pages/locationview.page.buildings/public/js/buildings.js
+++ b/floor-analytics-demo/building-visualizer/component/ui/src/main/resources/jaggeryapps/buildingmonitor/app/pages/locationview.page.buildings/public/js/buildings.js
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 var webSocket;
 var floorData = [];
 var rangeSlider;


### PR DESCRIPTION
## Purpose
> Adding missing license headers in JS files in BuildingMonitor sample

## Goals
> Adding license headers in missing files

## Approach
> N/A

## User stories
> N/A

## Release note
> Adding missing license headers in JS files in BuildingMonitor sample

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK version: java 1.8.0_141
Operating System: Linux Ubuntu
 
## Learning
> N/A